### PR TITLE
Cambio en la URL del logout de usuarios

### DIFF
--- a/decide/authentication/templates/bienvenida.html
+++ b/decide/authentication/templates/bienvenida.html
@@ -8,7 +8,7 @@
         {% if user.is_authenticated %}
             <h1>Hola {{ user.first_name }}</h1>
 
-            <a href="{% url 'logout' %}">Cerrar sesión</a>        
+            <a href="{% url 'userlogout' %}">Cerrar sesión</a>      
         {% else %}
             <a href="{% url 'sign_in' %}">Registrate</a>
             <a href="{% url 'sign_in' %}">Iniciar sesión con usuario/contraseña</a>

--- a/decide/authentication/urls.py
+++ b/decide/authentication/urls.py
@@ -18,8 +18,7 @@ urlpatterns = [
     path('loginLDAP/', LDAPLogin.as_view(), name='loginldap'),
     path('login_form/', SignInView.as_view(), name='sign_in'),
     path('bienvenida/', BienvenidaView.as_view()),
-    # path('logout/', cerrarsesion, name="logout"),
+    path('userlogout/', cerrarsesion, name="userlogout"),
     path('', include(router.urls)),
     path('api-auth/', include('rest_framework.urls', namespace='rest_framework')),
-    # path('', inicio),
 ]


### PR DESCRIPTION
Se ha cambiado la redirección para cerrar la sesión de un usuario ya que tenía conflicto con el método LogoutView de Django Rest.