### PR TITLE
<bug>: <ldap> Votaciones arregladas para usuarios LDAP

### DIFF
--- a/decide/authentication/urls.py
+++ b/decide/authentication/urls.py
@@ -3,7 +3,7 @@ from django.urls import include, path
 from rest_framework.authtoken.views import obtain_auth_token
 from rest_framework import routers
 
-from .views import BienvenidaView, GetUserView, LogoutView, RegisterView, LDAPLogin, SignInView, cerrarsesion, LDAPSignInView,RegisterUserView,landingpage
+from .views import BienvenidaView, GetUserView, LogoutView, RegisterView, LDAPLogin, SignInView, cerrarsesion,RegisterUserView,landingpage
 from . import views
 
 router = routers.DefaultRouter()

--- a/decide/authentication/views.py
+++ b/decide/authentication/views.py
@@ -1,3 +1,5 @@
+from base import mods
+
 from django.db.models.fields import EmailField
 from rest_framework.response import Response
 from rest_framework import viewsets
@@ -75,7 +77,6 @@ class LDAPLogin(APIView):
     Class to authenticate a user via LDAP and
     then creating a login session
     """
-    authentication_classes = ()
 
     def post(self, request):
         """
@@ -83,7 +84,6 @@ class LDAPLogin(APIView):
         :param request:
         :return:
         """
-
         try:
             # Probamos la conexion con el servidor con las siguientes instrucciones
             con = ldap.initialize(AUTH_LDAP_SERVER_URI)
@@ -92,38 +92,26 @@ class LDAPLogin(APIView):
                 # Probamos a logear con los datos enviados por el usuario
                 user_obj = authenticate(username=request.data['username'],
                                         password=request.data['password'])
-                login(request, user_obj,
-                      backend='django_auth_ldap.backend.LDAPBackend')
-                data = {'detail': 'User logged in successfully'}
-                status = HTTP_200_OK
+                login(request, user_obj, backend='django_auth_ldap.backend.LDAPBackend')
+                
+                #Añadir token al sesion para poder votar, en otro caso el votar 
+                #con un usuario registrado con ldap resulta en un panic
+                if user_obj and request.content_type == 'application/x-www-form-urlencoded':
+                    user_data = {
+                        'username': request.data['username'],
+                        'password': request.data['password'],
+                    }
+                    token = mods.post('authentication', entry_point='/login/', json=user_data)
+                    request.session['auth-token'] = token['token']
+
+                response = Response({'detail': 'User logged in successfully'}, status=HTTP_200_OK)
+                return render(request, 'welcome.html', status=HTTP_200_OK)
             except AttributeError:
-                data = {'detail': 'Credenciales mal'}
-                status = HTTP_400_BAD_REQUEST
+                response = Response({'detail': 'Credenciales mal'}, status=HTTP_400_BAD_REQUEST)
+                return render(request, 'welcome.html', status=HTTP_400_BAD_REQUEST)
         except ldap.SERVER_DOWN:
-            data = {'detail': 'Problema con el servicio LDAP'}
-            status = HTTP_500_INTERNAL_SERVER_ERROR
-        return render(request, 'welcome.html', status=status)
-
-
-class LDAPLogout(APIView):
-    """
-    Class for logging out a user by clearing his/her session
-    """
-    permission_classes = (IsAuthenticated,)
-
-    def post(self, request):
-        """
-        Api to logout a user
-        :param request:
-        :return:
-        """
-        logout(request)
-        data = {'detail': 'User logged out successfully'}
-        return Response(data, status=200)
-
-
-class LDAPSignInView(LoginView):
-    template_name = 'login_ldap_view.html'
+            response = Response({'detail': 'Problema con el servicio LDAP'}, status=HTTP_500_INTERNAL_SERVER_ERROR)
+            return render(request, 'welcome.html', status=HTTP_500_INTERNAL_SERVER_ERROR)
 
 
 class SignInView(LoginView):
@@ -169,7 +157,7 @@ class UserViewSet(viewsets.ModelViewSet):
 
 def cerrarsesion(request):
     print("==========================LOGOUT========================")
-
+    
     logout(request)
     messages.success(request, F"Su sesión se ha cerrado correctamente")
     return render(request, "welcome.html")

--- a/decide/authentication/views.py
+++ b/decide/authentication/views.py
@@ -13,7 +13,6 @@ from rest_framework.status import (
 )
 from rest_framework.views import APIView
 from rest_framework.authtoken.models import Token
-from rest_framework.permissions import IsAuthenticated
 
 from django.contrib.auth.models import User
 from django.contrib.auth import authenticate, login, logout
@@ -94,8 +93,7 @@ class LDAPLogin(APIView):
                                         password=request.data['password'])
                 login(request, user_obj, backend='django_auth_ldap.backend.LDAPBackend')
                 
-                #Añadir token al sesion para poder votar, en otro caso el votar 
-                #con un usuario registrado con ldap resulta en un panic
+                #Añadir token al sesion para poder votar, en otro caso el votar con un usuario registrado con ldap resulta en un panic
                 if user_obj and request.content_type == 'application/x-www-form-urlencoded':
                     user_data = {
                         'username': request.data['username'],
@@ -104,13 +102,10 @@ class LDAPLogin(APIView):
                     token = mods.post('authentication', entry_point='/login/', json=user_data)
                     request.session['auth-token'] = token['token']
 
-                response = Response({'detail': 'User logged in successfully'}, status=HTTP_200_OK)
                 return render(request, 'welcome.html', status=HTTP_200_OK)
             except AttributeError:
-                response = Response({'detail': 'Credenciales mal'}, status=HTTP_400_BAD_REQUEST)
                 return render(request, 'welcome.html', status=HTTP_400_BAD_REQUEST)
         except ldap.SERVER_DOWN:
-            response = Response({'detail': 'Problema con el servicio LDAP'}, status=HTTP_500_INTERNAL_SERVER_ERROR)
             return render(request, 'welcome.html', status=HTTP_500_INTERNAL_SERVER_ERROR)
 
 


### PR DESCRIPTION
Ahora los usuarios que inicien sesion desde ldap pueden votar correctamente
![Captura de pantalla de 2022-01-09 04-57-39](https://user-images.githubusercontent.com/72742676/148675880-791b2390-3565-4c22-9786-a01dca195309.png)
Una vez de que Django verifica las credenciales del usuario LDAP externo almacena al usuario en su base de datos.
![Captura de pantalla de 2022-01-09 04-58-20](https://user-images.githubusercontent.com/72742676/148675929-35da0501-3064-4b35-85d8-61f82c432ace.png)
Se asigna al usuario LDAP a una votación
![Captura de pantalla de 2022-01-09 04-58-45](https://user-images.githubusercontent.com/72742676/148675944-ff8f27e3-a630-418b-bfb6-dffeb6c79865.png)
Se puede observar que ya no salta el error al acceder al 'auth-token' que debería de estar en request.session
![Captura de pantalla de 2022-01-09 04-58-52](https://user-images.githubusercontent.com/72742676/148675961-6340d578-53c0-4942-bc77-298fb89c82cf.png) 
También se envía el voto con normalidad

![Captura de pantalla de 2022-01-09 04-59-21](https://user-images.githubusercontent.com/72742676/148675996-7f34f227-6b0a-4ba2-966a-8d79c55debc9.png)

![Captura de pantalla de 2022-01-09 05-01-20](https://user-images.githubusercontent.com/72742676/148675999-a557a621-1dd6-466d-a6e6-8d4a7cde25fd.png)

Close #60 

